### PR TITLE
Bugfix/remove item from saved cart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Development environment files
+/.idea
+/.vscode
+/.vagrant
+/.grunt
+/.php_cs.cache
+/composer.phar
+*.sql
+
+# Ignore merge conflict leftovers
+*~*
+*.orig
+
+# OS/IDE auto-generated files
+.DS_Store
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+_notes
+
+# gitkeeps
+!**/.gitkeep

--- a/Controller/Cart/UpdatePost.php
+++ b/Controller/Cart/UpdatePost.php
@@ -11,173 +11,201 @@ use Magento\Framework\App\RequestInterface;
 
 class UpdatePost extends \Magento\Checkout\Controller\Cart
 {
-    /**
-     * @var CartRepositoryInterface
-     */
-    private $quoteRepository;
+	/**
+	 * @var CartRepositoryInterface
+	 */
+	private $quoteRepository;
 
-    /**
-     * @var SaveCartRepositoryInterface
-     */
-    private $saveCartRepository;
+	/**
+	 * @var SaveCartRepositoryInterface
+	 */
+	private $saveCartRepository;
 
-    /**
-     * @var \Magento\Customer\Model\Session
-     */
-    private $customerSession;
+	/**
+	 * @var \Magento\Customer\Model\Session
+	 */
+	private $customerSession;
 
-    /**
-     * @var SaveCartModelFactory
-     */
-    private $saveCartModelFactory;
+	/**
+	 * @var SaveCartModelFactory
+	 */
+	private $saveCartModelFactory;
 
-    /**
-     * @param \Magento\Framework\App\Action\Context $context
-     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
-     * @param \Magento\Checkout\Model\Session $checkoutSession
-     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
-     * @param \Magento\Framework\Data\Form\FormKey\Validator $formKeyValidator
-     * @param CustomerCart $cart
-     * @param CartRepositoryInterface $quoteRepository
-     */
-    public function __construct(
-        \Magento\Framework\App\Action\Context $context,
-        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
-        \Magento\Checkout\Model\Session $checkoutSession,
-        \Magento\Store\Model\StoreManagerInterface $storeManager,
-        \Magento\Framework\Data\Form\FormKey\Validator $formKeyValidator,
-        CustomerCart $cart,
-        CartRepositoryInterface $quoteRepository,
-        SaveCartRepositoryInterface $saveCartRepository,
-        \Magento\Customer\Model\Session $customerSession,
-        SaveCartModelFactory $saveCartModelFactory
-    ) {
-        parent::__construct($context, $scopeConfig, $checkoutSession, $storeManager, $formKeyValidator, $cart);
-        $this->quoteRepository = $quoteRepository;
-        $this->saveCartRepository = $saveCartRepository;
-        $this->customerSession = $customerSession;
-        $this->saveCartModelFactory = $saveCartModelFactory;
-    }
+	/**
+	 * @param \Magento\Framework\App\Action\Context $context
+	 * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+	 * @param \Magento\Checkout\Model\Session $checkoutSession
+	 * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+	 * @param \Magento\Framework\Data\Form\FormKey\Validator $formKeyValidator
+	 * @param CustomerCart $cart
+	 * @param CartRepositoryInterface $quoteRepository
+	 */
+	public function __construct(
+		\Magento\Framework\App\Action\Context $context,
+		\Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
+		\Magento\Checkout\Model\Session $checkoutSession,
+		\Magento\Store\Model\StoreManagerInterface $storeManager,
+		\Magento\Framework\Data\Form\FormKey\Validator $formKeyValidator,
+		CustomerCart $cart,
+		CartRepositoryInterface $quoteRepository,
+		SaveCartRepositoryInterface $saveCartRepository,
+		\Magento\Customer\Model\Session $customerSession,
+		SaveCartModelFactory $saveCartModelFactory
+	) {
+		parent::__construct($context, $scopeConfig, $checkoutSession, $storeManager, $formKeyValidator, $cart);
+		$this->quoteRepository = $quoteRepository;
+		$this->saveCartRepository = $saveCartRepository;
+		$this->customerSession = $customerSession;
+		$this->saveCartModelFactory = $saveCartModelFactory;
+	}
 
-    /**
-     * Check customer authentication for some actions
-     *
-     * @param RequestInterface $request
-     * @return \Magento\Framework\App\ResponseInterface
-     */
-    public function dispatch(RequestInterface $request)
-    {
-        if (!$this->customerSession->authenticate()) {
-            $this->_actionFlag->set('', 'no-dispatch', true);
-        }
-        return parent::dispatch($request);
-    }
+	/**
+	 * Check customer authentication for some actions
+	 *
+	 * @param RequestInterface $request
+	 * @return \Magento\Framework\App\ResponseInterface
+	 */
+	public function dispatch(RequestInterface $request)
+	{
+		if (!$this->customerSession->authenticate()) {
+			$this->_actionFlag->set('', 'no-dispatch', true);
+		}
+		return parent::dispatch($request);
+	}
 
-    /**
-     * Update customer's shopping cart
-     *
-     * @return void
-     */
-    protected function _updateShoppingCart()
-    {
-        try {
-            $cartData = $this->getRequest()->getParam('cart');
-            if (is_array($cartData)) {
-                $filter = new \Zend_Filter_LocalizedToNormalized(
-                    ['locale' => $this->_objectManager->get('Magento\Framework\Locale\ResolverInterface')->getLocale()]
-                );
-                foreach ($cartData as $index => $data) {
-                    if (isset($data['qty'])) {
-                        $cartData[$index]['qty'] = $filter->filter(trim($data['qty']));
-                    }
-                }
-                if (!$this->cart->getCustomerSession()->getCustomerId() && $this->cart->getQuote()->getCustomerId()) {
-                    $this->cart->getQuote()->setCustomerId(null);
-                }
+	/**
+	 * Update customer's shopping cart
+	 *
+	 * @return void
+	 */
+	protected function _updateShoppingCart()
+	{
+		try {
+			$cartData = $this->getRequest()->getParam('cart');
+			if (is_array($cartData)) {
+				$filter = new \Zend_Filter_LocalizedToNormalized(
+					['locale' => $this->_objectManager->get('Magento\Framework\Locale\ResolverInterface')->getLocale()]
+				);
+				foreach ($cartData as $index => $data) {
+					if (isset($data['qty'])) {
+						$cartData[$index]['qty'] = $filter->filter(trim($data['qty']));
+					}
+				}
+				if (!$this->cart->getCustomerSession()->getCustomerId() && $this->cart->getQuote()->getCustomerId()) {
+					$this->cart->getQuote()->setCustomerId(null);
+				}
 
-                $cartData = $this->cart->suggestItemsQty($cartData);
-                $this->setSaveCartData($cartData);
-                $this->cart->updateItems($cartData);
-                    //->save();
-                //avoid call save method because it update current quote
-                $this->cart->getQuote()->getBillingAddress();
-                $this->cart->getQuote()->getShippingAddress()->setCollectShippingRates(true);
-                $this->cart->getQuote()->collectTotals();
-                $this->quoteRepository->save($this->cart->getQuote());
-            }
-        } catch (\Magento\Framework\Exception\LocalizedException $e) {
-            $this->messageManager->addError(
-                $this->_objectManager->get('Magento\Framework\Escaper')->escapeHtml($e->getMessage())
-            );
-        }
-    }
+				$cartData = $this->cart->suggestItemsQty($cartData);
+				$this->setSaveCartData($cartData);
+				$this->cart->updateItems($cartData);
+				//->save();
+				//avoid call save method because it update current quote
+				$this->cart->getQuote()->getBillingAddress();
+				$this->cart->getQuote()->getShippingAddress()->setCollectShippingRates(true);
+				$this->cart->getQuote()->collectTotals();
+				$this->quoteRepository->save($this->cart->getQuote());
+			}
+		} catch (\Magento\Framework\Exception\LocalizedException $e) {
+			$this->messageManager->addError(
+				$this->_objectManager->get('Magento\Framework\Escaper')->escapeHtml($e->getMessage())
+			);
+		}
+	}
 
-    protected function setSaveCartData($cartData)
-    {
-        $quote = $this->cart->getQuote();
-        try {
-            $savedCart = $this->saveCartRepository->get($quote->getId());
-        } catch (NoSuchEntityException $e) {
-            $savedCart = $this->saveCartModelFactory->create();
-            $savedCart->setQuoteId($quote->getId());
-        }
-        $savedCart->setQuoteName($cartData['quote_name']);
-        $savedCart->setQuoteComment($cartData['quote_comment']);
-        $savedCart->setCustomerId($quote->getCustomerId());
+	protected function _deleteItem()
+	{
+		$id = (int)$this->getRequest()->getParam('quote_item_id');
+		if ($id) {
+			try {
+				$this->cart->removeItem($id);
+				if (!$this->cart->getCustomerSession()->getCustomerId() && $this->cart->getQuote()->getCustomerId()) {
+					$this->cart->getQuote()->setCustomerId(null);
+				}
+				$this->quoteRepository->save($this->cart->getQuote());
+			} catch (\Exception $e) {
+				$this->messageManager->addError(
+					$this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e)
+				);
+			}
+		}
+	}
 
-        $extensionAttributes = $quote->getExtensionAttributes();
+	protected function setSaveCartData($cartData)
+	{
+		$quote = $this->cart->getQuote();
+		try {
+			$savedCart = $this->saveCartRepository->get($quote->getId());
+		} catch (NoSuchEntityException $e) {
+			$savedCart = $this->saveCartModelFactory->create();
+			$savedCart->setQuoteId($quote->getId());
+		}
+		$savedCart->setQuoteName($cartData['quote_name']);
+		$savedCart->setQuoteComment($cartData['quote_comment']);
+		$savedCart->setCustomerId($quote->getCustomerId());
 
-        if ($extensionAttributes === null) {
-            $extensionAttributes = $this->cartExtensionFactory->create();
-        }
+		$extensionAttributes = $quote->getExtensionAttributes();
 
-        $extensionAttributes->setSaveCartData($savedCart);
-        $quote->setExtensionAttributes($extensionAttributes);
-    }
+		if ($extensionAttributes === null) {
+			$extensionAttributes = $this->cartExtensionFactory->create();
+		}
 
-    /**
-     * Update shopping cart data action
-     *
-     * @return \Magento\Framework\Controller\Result\Redirect
-     */
-    public function execute()
-    {
-        if (!$this->_formKeyValidator->validate($this->getRequest())) {
-            return $this->resultRedirectFactory->create()->setPath('*/*/');
-        }
+		$extensionAttributes->setSaveCartData($savedCart);
+		$quote->setExtensionAttributes($extensionAttributes);
+	}
 
-        $updateAction = (string)$this->getRequest()->getParam('update_cart_action');
-        $quoteId = $this->getRequest()->getParam('quote_id');
+	/**
+	 * Update shopping cart data action
+	 *
+	 * @return \Magento\Framework\Controller\Result\Redirect
+	 */
+	public function execute()
+	{
+		if (!$this->_formKeyValidator->validate($this->getRequest())) {
+			return $this->resultRedirectFactory->create()->setPath('*/*/');
+		}
 
-        try {
-            $quote = $this->quoteRepository->get($quoteId);
-            if ($quote->getCustomerId() == $this->customerSession->getCustomerId()) {
-                $this->cart->setQuote($quote);
-                $this->_updateShoppingCart();
+		$updateAction = (string)$this->getRequest()->getParam('update_cart_action');
+		$quoteId = $this->getRequest()->getParam('quote_id');
 
-                switch ($updateAction) {
-                    case 'save':
-                        $this->_checkoutSession->clearQuote()->clearStorage();
-                        $this->messageManager->addSuccessMessage(
-                            __('The main cart contents has been transferred to the quote.')
-                        );
-                        $resultRedirect = $this->resultRedirectFactory->create();
-                        $resultRedirect->setPath('savecart/cart');
-                        return $resultRedirect;
-                    case 'update':
-                        $this->messageManager->addSuccessMessage(
-                            __('Quote has been updated.')
-                        );
-                        break;
-                }
-            }
-        } catch (NoSuchEntityException $e) {
-            $this->messageManager->addException($e, __('We can\'t update the shopping cart.'));
-        } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('We can\'t update the shopping cart.'));
-            $this->_objectManager->get('Psr\Log\LoggerInterface')->critical($e);
-        }
+		try {
+			$quote = $this->quoteRepository->get($quoteId);
+			if ($quote->getCustomerId() == $this->customerSession->getCustomerId()) {
+				$this->cart->setQuote($quote);
 
-        return $this->_goBack();
-    }
+				if ($updateAction == 'remove_item') {
+					$this->_deleteItem();
+
+					$this->messageManager->addSuccessMessage(
+						__('Item has been removed.')
+					);
+				}
+				else {
+					$this->_updateShoppingCart();
+
+					switch ($updateAction) {
+						case 'save':
+							$this->_checkoutSession->clearQuote()->clearStorage();
+							$this->messageManager->addSuccessMessage(
+								__('The main cart contents has been transferred to the quote.')
+							);
+							$resultRedirect = $this->resultRedirectFactory->create();
+							$resultRedirect->setPath('savecart/cart');
+							return $resultRedirect;
+						case 'update':
+							$this->messageManager->addSuccessMessage(
+								__('Quote has been updated.')
+							);
+							break;
+					}
+				}
+			}
+		} catch (NoSuchEntityException $e) {
+			$this->messageManager->addException($e, __('We can\'t update the shopping cart.'));
+		} catch (\Exception $e) {
+			$this->messageManager->addException($e, __('We can\'t update the shopping cart.'));
+			$this->_objectManager->get('Psr\Log\LoggerInterface')->critical($e);
+		}
+
+		return $this->_goBack();
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,14 @@
         {
             "name": "Oleksandr Vekeryk",
             "email": "alexandervekerik@gmail.com"
+        },
+        {
+            "name": "Jim Chao",
+            "email": "jchao@ripen.com"
+        },
+        {
+            "name": "Misha Medvedev",
+            "email": "mmedvedev@ripen.com"
         }
     ],
     "description": "Magento 2 save cart extension",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Vekeryk_SaveCart" setup_version="1.0.0">
+    <module name="Vekeryk_SaveCart" setup_version="1.1.0">
         <sequence>
             <module name="Magento_Checkout"/>
         </sequence>

--- a/view/frontend/layout/savecart_cart_edit.xml
+++ b/view/frontend/layout/savecart_cart_edit.xml
@@ -14,5 +14,15 @@
                 </action>
             </referenceBlock>
         </referenceContainer>
+        <referenceBlock name="checkout.cart.item.renderers.default.actions.remove">
+            <action method="setTemplate">
+                <argument name="template" xsi:type="string">Vekeryk_SaveCart::cart/item/renderer/actions/remove.phtml</argument>
+            </action>
+        </referenceBlock>
+        <referenceBlock name="checkout.cart.item.renderers.simple.actions.remove">
+            <action method="setTemplate">
+                <argument name="template" xsi:type="string">Vekeryk_SaveCart::cart/item/renderer/actions/remove.phtml</argument>
+            </action>
+        </referenceBlock>
     </body>
 </page>

--- a/view/frontend/templates/cart/item/renderer/actions/remove.phtml
+++ b/view/frontend/templates/cart/item/renderer/actions/remove.phtml
@@ -1,0 +1,14 @@
+<?php
+// @codingStandardsIgnoreFile
+
+/** @var \Magento\Checkout\Block\Cart\Item\Renderer\Actions\Remove $block */
+/** @var Magento\Quote\Model\Quote\Item $item */
+$item = $this->getItem();
+?>
+<button type="submit"
+        name="remove_item_action"
+        value="remove_item"
+        title="<?php echo $block->escapeHtml(__('Remove item')); ?>"
+        class="action action-delete">
+    <span><?php /* @escapeNotVerified */ echo __('Remove item'); ?></span>
+</button>


### PR DESCRIPTION
This PR aims to enable proper deletion of items on user's saved carts by accomplishing the following:

1. Override Magento_Checkout's cart item renderer delete action block; the default delete action calls on Magento\Checkout\Controller\Cart\Delete, but the deletion action there only affects the current active cart, and not the saved cart/quote itself
2. Update UpdatePost to handle item deletion, making sure the saved cart/quote is updated as a result
